### PR TITLE
Fix Web support page highlighting in left nav

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -512,7 +512,7 @@
       permalink: /platform-integration/web
       children:
         - title: Web support in Flutter
-          permalink: /platform-integration/web/
+          permalink: /platform-integration/web
         - title: Add web as build target
           permalink: /platform-integration/web/install-web
         - title: Build a web app


### PR DESCRIPTION
The new page "Web support for Flutter" wasn't showing an active highlight in the left nav (see screenshots). Looks like there was an extraneous trailing slash.

VERY minor change

Web support for Flutter: No active highlight:
![Screenshot 2024-11-21 at 10 08 16](https://github.com/user-attachments/assets/20fd1984-d47c-4542-a42b-9d1b2dfd08db)

Other pages have:
![Screenshot 2024-11-21 at 10 09 00](https://github.com/user-attachments/assets/86130298-5b9b-43a7-a718-e60b775d5462)


